### PR TITLE
Outputs become non-optional (mostly)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.2.4 - 2022-05-25
+- Change most output types to non-optional. Classified as a bug fix. Filtered outputs are still optional!
 ## 2.2.3 - 2022-02-02
 - Add timeout and modules param to interval-processing task so that we can use modularized data
 ## 2.2.2 - 2021-06-02

--- a/README.md
+++ b/README.md
@@ -129,10 +129,10 @@ Parameter|Value|Default|Description
 Output | Type | Description
 ---|---|---
 `resultCnvFile`|File?|file with CNV calls, smoothed
-`resultSnpFile`|File?|file with SNPs, native varscan format
-`resultIndelFile`|File?|file with Indel calls, native varscan format
-`resultSnpVcfFile`|File?|file with SNPs, vcf format
-`resultIndelVcfFile`|File?|file with Indels, vcf format
+`resultSnpFile`|File|file with SNPs, native varscan format
+`resultIndelFile`|File|file with Indel calls, native varscan format
+`resultSnpVcfFile`|File|file with SNPs, vcf format
+`resultIndelVcfFile`|File|file with Indels, vcf format
 
 
 ## Commands

--- a/varscan.wdl
+++ b/varscan.wdl
@@ -37,9 +37,9 @@ call mergeVariantsVcf as mergeSNPvcf { input: filePaths = select_all(getSnvVcf.s
 call mergeVariantsVcf as mergeINDvcf { input: filePaths = select_all(getSnvVcf.indelVcfFile), outputSuffix = "indel", outputFile = sampleID }
 
 # Run post-processing job if we have results from runVarscanCNV
-Array[File] cNumberFile = select_all([mergeCNV.mergedVariants])
+Array[File] cNumberFile = [mergeCNV.mergedVariants]
 if (length(cNumberFile) == 1) {
-    call smoothData{input: copyNumberFile = select_first([mergeCNV.mergedVariants]), sampleID = sampleID}
+    call smoothData{input: copyNumberFile = mergeCNV.mergedVariants, sampleID = sampleID}
 }
 
 meta {

--- a/varscan.wdl
+++ b/varscan.wdl
@@ -86,11 +86,11 @@ parameter_meta {
 }
 
 output {
- File? resultCnvFile      = smoothData.filteredData
- File? resultSnpFile      = mergeSNP.mergedVariants
- File? resultIndelFile    = mergeIND.mergedVariants
- File? resultSnpVcfFile   = mergeSNPvcf.mergedVcf
- File? resultIndelVcfFile = mergeINDvcf.mergedVcf
+ File? resultCnvFile     = smoothData.filteredData
+ File resultSnpFile      = mergeSNP.mergedVariants
+ File resultIndelFile    = mergeIND.mergedVariants
+ File resultSnpVcfFile   = mergeSNPvcf.mergedVcf
+ File resultIndelVcfFile = mergeINDvcf.mergedVcf
 }
 
 }
@@ -220,7 +220,7 @@ runtime {
 }
 
 output {
-  File? mergedVariants = "~{outputFile}.~{outputExtension}"
+  File mergedVariants = "~{outputFile}.~{outputExtension}"
 }
 }
 
@@ -264,7 +264,7 @@ runtime {
 }
 
 output {
-  File? mergedVcf = "~{outputFile}.~{outputSuffix}.vcf"
+  File mergedVcf = "~{outputFile}.~{outputSuffix}.vcf"
 }
 }
 


### PR DESCRIPTION
Having all outputs as Optional type results in errors (External IDs do not match) in _shesmu_. Best practices require at least one non-optional output. However, a brief review shows that in the most (most likely all) cases we will have **copynumber** and **snp** files (not filtered files, though).