### PR TITLE
Neoantigen pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,34 +1,77 @@
-## 2.5.1 - 2025-03-10
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+
+## [2.5.1] - 2025-03-10
+### Added
 - Added vcfCombine task to create a final bgzipped vcf with both indels and cnv
-## 2.5.0 - 2024-06-25
+
+## [2.5.0] - 2024-06-25
+### Added
 [GRD-797](https://jira.oicr.on.ca/browse/GRD-797) - add vidarr labels to outputs (changes to medata only)
-## 2.4.1 - 2024-02-12
+
+## [2.4.1] - 2024-02-12
+### Added
+
 - Added minMemory parameter to tasks using RAM scaling (to handle small chromosomes better)
-## 2.4.0 - 2023-12-16
+
+## [2.4.0] - 2023-12-16
+### Added
+
 - Added scaling RAM assignment by chromosome for scattered tasks
-## 2.3.0 - 2023-06-21
+
+## [2.3.0] - 2023-06-21
+### Added
 - Assembly-specific settings go into wdl
-## 2.2.5 - 2023-06-08
+
+## [2.2.5] - 2023-06-08
+### Changed
 - Increment version to install varscan_matched in Vidarr
-## Unreleased
+
+## [Unreleased]
+### Changed
 - updated README, explained passing interval file better
-## 2.2.4 - 2022-05-25
+
+## [2.2.4] - 2022-05-25
+### Changed
 - Change most output types to non-optional. Classified as a bug fix. Filtered outputs are still optional!
-## 2.2.3 - 2022-02-02
+
+## [2.2.3] - 2022-02-02
+### Added
 - Add timeout and modules param to interval-processing task so that we can use modularized data
-## 2.2.2 - 2021-06-02
+
+## [2.2.2] - 2021-06-02
+### Fixed
 - This version increment was to resolve installation issues in vidarr
-## Unreleased - 2021-11-10
+
+## [Unreleased] - 2021-11-10
+### Fixed
 [GP-2891](https://jira.oicr.on.ca/browse/GP-2891) Making RT tests more robust
-## 2.2.1 - 2021-02-01
+
+## [2.2.1] - 2021-02-01
+### Fixed
 - Increment version to avoid overlap with a compromized installation
-## 2.2   - 2021-01-15
+
+## [2.2]   - 2021-01-15
+### Changed
 - Re-implemented to cut on merging pileups and scatter variant-calling tasks
-## 2.1.1 - 2020-04-06
+
+## [2.1.1] - 2020-04-06
+### Added
 - Added timeout setting to mpileup concatenation step. 5 hr is not enough for some data
-## 2.1 - 2020-04-02
+
+## [2.1] - 2020-04-02
+### Changed
 - Introduced compression of mpileup data to conserve disk space
-## 2.0 - 2020-01-31
+
+## [2.0] - 2020-01-31
 - Converting to wdl workflow, adding more output types to mesh well with sequenza
-## 1.0 - 2017-08-16
+
+## [1.0] - 2017-08-16
 - Initial implementation as a stand-alone workflow
+
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.5.1 - 2025-03-10
+- Added vcfCombine task to create a final bgzipped vcf with both indels and cnv
 ## 2.5.0 - 2024-06-25
 [GRD-797](https://jira.oicr.on.ca/browse/GRD-797) - add vidarr labels to outputs (changes to medata only)
 ## 2.4.1 - 2024-02-12

--- a/README.md
+++ b/README.md
@@ -235,15 +235,17 @@ Output | Type | Description | Labels
  
  ```
  set -eo pipefail
-         # bgzip and index the vcf files
- 	bgzip -c ~{vcfSnvs} > ~{outputFileNamePrefix}.varscan2_snv.vcf
- 	tabix ~{outputFileNamePrefix}.varscan2_snv.vcf.gz
- >-------bgzip -c ~{vcfSnvs} > ~{outputFileNamePrefix}.varscan2_indel.vcf
- >-------tabix ~{outputFileNamePrefix}.varscan2_snv.vcf.gz
-         # concat into a single output, bgzip and index
- 	bcftools concat -a -o ~{outputFileNamePrefix}.varscan2_all.vcf ~{outputFileNamePrefix}.varscan2_snv.vcf.gz ~{outputFileNamePrefix}.varscan2_indel.vcf.gz
- 	bgzip ~{outputFileNamePrefix}.varscan2_all.vcf
- 	tabix ~{outputFileNamePrefix}.varscan2_all.vcf.gz
+ 
+ # bgzip and index the vcf files
+ bgzip -c ~{vcfSnvs} > ~{outputFileNamePrefix}.varscan2_snv.vcf
+ tabix ~{outputFileNamePrefix}.varscan2_snv.vcf.gz
+ bgzip -c ~{vcfSnvs} > ~{outputFileNamePrefix}.varscan2_indel.vcf
+ tabix ~{outputFileNamePrefix}.varscan2_snv.vcf.gz
+ 
+ # concat into a single output, bgzip and index
+ bcftools concat -a -o ~{outputFileNamePrefix}.varscan2_all.vcf ~{outputFileNamePrefix}.varscan2_snv.vcf.gz ~{outputFileNamePrefix}.varscan2_indel.vcf.gz
+ bgzip ~{outputFileNamePrefix}.varscan2_all.vcf
+ tabix ~{outputFileNamePrefix}.varscan2_all.vcf.gz
  ```
  
  

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 Varscan 2.3, workflow for calling SNVs and CVs
 Creation of mpileups and calling variants are done with parallel processing
+
 ![varscan outputs](docs/Screenshot_Varscan.png)
+
+## Overview
 
 ## Dependencies
 
@@ -10,6 +13,7 @@ Creation of mpileups and calling variants are done with parallel processing
 * [varscan 2.4.2](http://varscan.sourceforge.net)
 * [samtools 0.1.19](http://www.htslib.org/)
 * [rstats 3.6](http://cran.utstat.utoronto.ca/src/base/R-3/R-3.6.1.tar.gz)
+* [bcftools 1.9](https://github.com/samtools/bcftools)
 
 
 ## Usage
@@ -119,6 +123,10 @@ Parameter|Value|Default|Description
 `smoothData.recenter_down`|Int|0|Fine-tuning parameter for VarScan
 `smoothData.jobMemory`|Int|16|Memory in Gb for this job
 `smoothData.javaMemory`|Int|6|Memory in Gb for Java
+`vcfCombine.modules`|String|"bcftools/1.9 tabix/1.9"|environment modules
+`vcfCombine.jobMemory`|Int|16|Memory allocated for job
+`vcfCombine.threads`|Int|4|Number of threads for processing
+`vcfCombine.timeout`|Int|4|Hours before task timeout
 
 
 ### Outputs
@@ -130,26 +138,28 @@ Output | Type | Description | Labels
 `resultIndelFile`|File|file with Indel calls, native varscan format|vidarr_label: resultIndelFile
 `resultSnpVcfFile`|File|file with SNPs, vcf format|vidarr_label: resultSnpVcfFile
 `resultIndelVcfFile`|File|file with Indels, vcf format|vidarr_label: resultIndelVcfFile
+`resultVcfFile`|File|file with snvs + indels, vcf format, bgzipped|vidarr_label: resultVcfFile
+`resultVcfFileIndex`|File|index file for snv + indels vcf output|vidarr_label: resultVcfFileIndex
 
 
 ## Commands
  
-This section lists command(s) run by varscan workflow
+ This section lists command(s) run by varscan workflow
  
-### Produce a scaling coefficient for allocating RAM
+  * Produce a scaling coefficient for allocating RAM
  
-```
-   CHROM=$(echo ~{region} | sed 's/:.*//')
-   grep -w SN:$CHROM ~{refDict} | cut -f 3 | sed 's/.*://' | awk '{print int(($1/~{largestChrom} + 0.1) * 10)/10}'
+ ```
+     CHROM=$(echo ~{region} | sed 's/:.*//')
+     grep -w SN:$CHROM ~{refDict} | cut -f 3 | sed 's/.*://' | awk '{print int(($1/~{largestChrom} + 0.1) * 10)/10}'
    
-```
+ ```
  
-### Preprocessing
+  * Preprocessing
  
-bed file re-format to be used with scattered pileup creation. Note that it should be a resonable ( <100 perhaps? ) intervals
-so that we do not end up with a million jobs running. Use wisely, as it may result in grabbing a lot of compute nodes.
+ bed file re-format to be used with scattered pileup creation. Note that it should be a resonable ( <100 perhaps? ) intervals
+ so that we do not end up with a million jobs running. Use wisely, as it may result in grabbing a lot of compute nodes.
  
-```
+ ```
   In this embedded script we reformat bed lines into varscan-friendly intervals
  
   import os
@@ -162,36 +172,36 @@ so that we do not end up with a million jobs running. Use wisely, as it may resu
             print(r)
      f.close()
  
-```
+ ```
  
-### Run samtools mpileup
+  * Run samtools mpileup
  
-```
+ ```
   samtools mpileup -q 1 -r REGION -f REF_FASTA INPUT_NORMAL INPUT_TUMOR | awk -F "\t" '$4 > 0 && $7 > 0' | gzip -c > normtumor_sorted.pileup.gz 
  
-```
+ ```
  
-### Remove mitochondrial chromosome:
+  * Remove mitochondrial chromosome:
  
-```
+ ```
   head -n 1 ~{filePaths[0]} > "~{outputFile}.~{outputExtension}"
   cat ~{sep=' ' filePaths} | sort -V -k 1,2 | grep -v ^chrom | grep -v ^chrM >> "~{outputFile}.~{outputExtension}"
   cat ~{sep=' ' filePaths} | awk '{if($1 == "chrM"){print $0}}' | sort -V -k 1,2 >> "~{outputFile}.~{outputExtension}"
   if [ ! -s ~{outputFile}.~{outputExtension} ] ; then
    rm ~{outputFile}.~{outputExtension}
   fi
-```
+ ```
  
-### Sort vcf using sequence dictionary
+  * Sort vcf using sequence dictionary
  
-```
+ ```
   java -Xmx[MEMORY]G -jar picard.jar SortVcf I=INPUT_VCFS SD=SEQ_DICTIONARY O=OUTPUT_FILE.SUFFIX.vcf
  
-```
+ ```
  
-### SNP/Indel Calling:
+  * SNP/Indel Calling:
  
-```
+ ```
    See the full source code in .wdl, here we run this command:
  
    zcat INPUT_PILEUP | java -Xmx[MEMORY]G -jar varscan somatic -mpileup 1 
@@ -218,11 +228,29 @@ so that we do not end up with a million jobs running. Use wisely, as it may resu
  
      --output-snp SAMPLE_ID.snp --output-indel SAMPLE_ID.indel
  
-```
+ ```
  
-### Find minimum coverage threshold for CV analysis:
+   * Merge the SNVs and Indels into a single file
+     The vcfCombine tasks combines the data and indexes the bgzipped output
  
-```
+ ```
+ set -eo pipefail
+         # bgzip and index the vcf files
+ 	bgzip -c ~{vcfSnvs} > ~{outputFileNamePrefix}.varscan2_snv.vcf
+ 	tabix ~{outputFileNamePrefix}.varscan2_snv.vcf.gz
+ >-------bgzip -c ~{vcfSnvs} > ~{outputFileNamePrefix}.varscan2_indel.vcf
+ >-------tabix ~{outputFileNamePrefix}.varscan2_snv.vcf.gz
+         # concat into a single output, bgzip and index
+ 	bcftools concat -a -o ~{outputFileNamePrefix}.varscan2_all.vcf ~{outputFileNamePrefix}.varscan2_snv.vcf.gz ~{outputFileNamePrefix}.varscan2_indel.vcf.gz
+ 	bgzip ~{outputFileNamePrefix}.varscan2_all.vcf
+ 	tabix ~{outputFileNamePrefix}.varscan2_all.vcf.gz
+ ```
+ 
+ 
+ 
+  * Find minimum coverage threshold for CV analysis:
+ 
+ ```
  
  A python code configures and runs this command: 
  
@@ -230,11 +258,11 @@ so that we do not end up with a million jobs running. Use wisely, as it may resu
  
  Varscan reports if the coverage threshold was sufficient for the analysis. We use this coverage setting in the next step
  
-```
+ ```
  
-### Run copy number change analysis:
+ ### Run copy number change analysis:
  
-```
+ ```
  
  A python code configures and runs this command:
   
@@ -252,9 +280,9 @@ so that we do not end up with a million jobs running. Use wisely, as it may resu
                     --recenter-up     RECENTER_UP
                     --recenter-down   RECENTER_DOWN
  
-```
+ ```
  
-## Support
+ ## Support
 
 For support, please file an issue on the [Github project](https://github.com/oicr-gsi) or send an email to gsi@oicr.on.ca .
 

--- a/commands.txt
+++ b/commands.txt
@@ -91,15 +91,17 @@ so that we do not end up with a million jobs running. Use wisely, as it may resu
 
 ```
 set -eo pipefail
-        # bgzip and index the vcf files
-	bgzip -c ~{vcfSnvs} > ~{outputFileNamePrefix}.varscan2_snv.vcf
-	tabix ~{outputFileNamePrefix}.varscan2_snv.vcf.gz
->-------bgzip -c ~{vcfSnvs} > ~{outputFileNamePrefix}.varscan2_indel.vcf
->-------tabix ~{outputFileNamePrefix}.varscan2_snv.vcf.gz
-        # concat into a single output, bgzip and index
-	bcftools concat -a -o ~{outputFileNamePrefix}.varscan2_all.vcf ~{outputFileNamePrefix}.varscan2_snv.vcf.gz ~{outputFileNamePrefix}.varscan2_indel.vcf.gz
-	bgzip ~{outputFileNamePrefix}.varscan2_all.vcf
-	tabix ~{outputFileNamePrefix}.varscan2_all.vcf.gz
+
+# bgzip and index the vcf files
+bgzip -c ~{vcfSnvs} > ~{outputFileNamePrefix}.varscan2_snv.vcf
+tabix ~{outputFileNamePrefix}.varscan2_snv.vcf.gz
+bgzip -c ~{vcfSnvs} > ~{outputFileNamePrefix}.varscan2_indel.vcf
+tabix ~{outputFileNamePrefix}.varscan2_snv.vcf.gz
+
+# concat into a single output, bgzip and index
+bcftools concat -a -o ~{outputFileNamePrefix}.varscan2_all.vcf ~{outputFileNamePrefix}.varscan2_snv.vcf.gz ~{outputFileNamePrefix}.varscan2_indel.vcf.gz
+bgzip ~{outputFileNamePrefix}.varscan2_all.vcf
+tabix ~{outputFileNamePrefix}.varscan2_all.vcf.gz
 ```
 
 

--- a/commands.txt
+++ b/commands.txt
@@ -86,6 +86,24 @@ so that we do not end up with a million jobs running. Use wisely, as it may resu
 
 ```
 
+  * Merge the SNVs and Indels into a single file
+    The vcfCombine tasks combines the data and indexes the bgzipped output
+
+```
+set -eo pipefail
+        # bgzip and index the vcf files
+	bgzip -c ~{vcfSnvs} > ~{outputFileNamePrefix}.varscan2_snv.vcf
+	tabix ~{outputFileNamePrefix}.varscan2_snv.vcf.gz
+>-------bgzip -c ~{vcfSnvs} > ~{outputFileNamePrefix}.varscan2_indel.vcf
+>-------tabix ~{outputFileNamePrefix}.varscan2_snv.vcf.gz
+        # concat into a single output, bgzip and index
+	bcftools concat -a -o ~{outputFileNamePrefix}.varscan2_all.vcf ~{outputFileNamePrefix}.varscan2_snv.vcf.gz ~{outputFileNamePrefix}.varscan2_indel.vcf.gz
+	bgzip ~{outputFileNamePrefix}.varscan2_all.vcf
+	tabix ~{outputFileNamePrefix}.varscan2_all.vcf.gz
+```
+
+
+
  * Find minimum coverage threshold for CV analysis:
 
 ```

--- a/varscan.wdl
+++ b/varscan.wdl
@@ -108,8 +108,8 @@ call vcfCombine {   input: vcfSnvs = mergeSNPvcf.mergedVcf,
 }
 
 meta {
-  author: "Peter Ruzanov"
-  email: "pruzanov@oicr.on.ca"
+  author: "Peter Ruzanov, Lawrence Heisler"
+  email: "pruzanov@oicr.on.ca, lheisler@oicr.on.ca"
   description: "Varscan 2.3, workflow for calling SNVs and CVs\nCreation of mpileups and calling variants are done with parallel processing\n\n![varscan outputs](docs/Screenshot_Varscan.png)"
 
   dependencies: [
@@ -128,6 +128,10 @@ meta {
       {
         name: "rstats/3.6",
         url: "http://cran.utstat.utoronto.ca/src/base/R-3/R-3.6.1.tar.gz"
+      },
+      {
+         name: "bcftools/1.9",
+         url: "https://github.com/samtools/bcftools"
       }
     ]
     

--- a/varscan.wdl
+++ b/varscan.wdl
@@ -101,6 +101,12 @@ if (length(cNumberFile) == 1) {
     call smoothData{input: copyNumberFile = mergeCNV.mergedVariants, sampleID = sampleID}
 }
 
+### merge the snv and indel vcf into a single file
+call vcfCombine {   input: vcfSnvs = mergeSNPvcf.mergedVcf,
+                           vcfIndels = mergeINDvcf.mergedVcf,
+                           outputFileNamePrefix = outputFileNamePrefix
+}
+
 meta {
   author: "Peter Ruzanov"
   email: "pruzanov@oicr.on.ca"
@@ -145,7 +151,17 @@ meta {
     resultIndelVcfFile: {
         description: "file with Indels, vcf format",
         vidarr_label: "resultIndelVcfFile"
+    },
+    resultVcfFile: {
+        description: "file with snvs + indels, vcf format, bgzipped",
+        vidarr_label: "resultVcfFile"
+    },
+    resultVcfFileIndex: {
+        description: "index file for snv + indels vcf output",
+        vidarr_label: "resultVcfFileIndex"
     }
+
+
 }
 }
 
@@ -166,9 +182,76 @@ output {
  File resultIndelFile    = mergeIND.mergedVariants
  File resultSnpVcfFile   = mergeSNPvcf.mergedVcf
  File resultIndelVcfFile = mergeINDvcf.mergedVcf
+ File resultVcfFile      = vcfCombine.vcf
+ File resultVcfFileIndex = vcfCombine.vcfIndex
 }
 
 }
+
+
+# ================================================================
+#  Combine the indel and snv vcfs into a single ouutput
+# ================================================================
+
+task vcfCombine {
+    input {
+	   File vcfSnvs
+	   File vcfIndels
+	   String modules = "bcftools/1.9 tabix/1.9"
+	   String outputFileNamePrefix
+	   Int jobMemory = 16
+	   Int threads = 4
+	   Int timeout = 4	   
+	
+	}
+
+    parameter_meta {
+	vcfSnvs: "vcf file with snvs"
+	vcfIndels: "vcf file with indels"
+	modules: "environment modules"
+	jobMemory: "Memory allocated for job"
+	timeout: "Hours before task timeout"
+	threads: "Number of threads for processing"
+    }
+
+	
+    command <<<
+	set -eo pipefail
+	
+	bgzip -c ~{vcfSnvs} > ~{outputFileNamePrefix}.varscan2_snv.vcf.gz
+	tabix ~{outputFileNamePrefix}.varscan2_snv.vcf.gz
+	bgzip -c ~{vcfIndels} > ~{outputFileNamePrefix}.varscan2_indel.vcf.gz
+	tabix ~{outputFileNamePrefix}.varscan2_indel.vcf.gz
+	bcftools concat -a -o ~{outputFileNamePrefix}.varscan2_all.vcf ~{outputFileNamePrefix}.varscan2_snv.vcf.gz ~{outputFileNamePrefix}.varscan2_indel.vcf.gz
+	bgzip ~{outputFileNamePrefix}.varscan2_all.vcf
+	tabix ~{outputFileNamePrefix}.varscan2_all.vcf.gz
+
+	>>>
+	
+    runtime {
+	modules: "~{modules}"
+	memory:  "~{jobMemory} GB"
+	cpu:     "~{threads}"
+	timeout: "~{timeout}"
+    }
+
+    output {
+	File vcf = "~{outputFileNamePrefix}.varscan2_all.vcf.gz"
+	File vcfIndex = "~{outputFileNamePrefix}.varscan2_all.vcf.gz.tbi"
+    }
+    
+	meta {
+	output_meta: {
+	    vcf: "VCF file with snvs and indels, bgzip compressed",
+	    vcfIndex: "tabix index"
+	}
+    }
+		
+
+}
+
+
+
 
 
 # ================================================================

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -149,7 +149,7 @@
             "varscan.vcfCombine.vcfIndels": null,
             "varscan.vcfCombine.modules": null,
             "varscan.vcfCombine.outputFileNamePrefix": null,
-            "varscan.vcfCombine.jobMemory": null
+            "varscan.vcfCombine.jobMemory": null,
             "varscan.vcfCombine.threads": null,
             "varscan.vcfCombine.timeout": null			
         },
@@ -376,7 +376,7 @@
             "varscan.vcfCombine.vcfIndels": null,
             "varscan.vcfCombine.modules": null,
             "varscan.vcfCombine.outputFileNamePrefix": null,
-            "varscan.vcfCombine.jobMemory": null
+            "varscan.vcfCombine.jobMemory": null,
             "varscan.vcfCombine.threads": null,
             "varscan.vcfCombine.timeout": null			
         },
@@ -610,7 +610,7 @@
             "varscan.vcfCombine.vcfIndels": null,
             "varscan.vcfCombine.modules": null,
             "varscan.vcfCombine.outputFileNamePrefix": null,
-            "varscan.vcfCombine.jobMemory": null
+            "varscan.vcfCombine.jobMemory": null,
             "varscan.vcfCombine.threads": null,
             "varscan.vcfCombine.timeout": null			
         },

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -192,6 +192,22 @@
                     }
                 ],
                 "type": "ALL"
+            },
+            "varscan.resultVcfFile": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_varscan_PCSI_chr22_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "varscan.resultVcfFileIndex": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_varscan_PCSI_chr22_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
             }
         },
         "validators": [
@@ -393,6 +409,22 @@
                 "contents": [
                     {
                         "outputDirectory": "@SCRATCH@/@DATE@_Workflow_varscan_PCSI_chr22_intervals_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "varscan.resultVcfFile": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_varscan_PCSI_chr22_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "varscan.resultVcfFileIndex": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_varscan_PCSI_chr22_@JENKINSID@"
                     }
                 ],
                 "type": "ALL"
@@ -604,6 +636,22 @@
                 "contents": [
                     {
                         "outputDirectory": "@SCRATCH@/@DATE@_Workflow_varscan_MATS_chr22_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "varscan.resultVcfFile": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_varscan_PCSI_chr22_@JENKINSID@"
+                    }
+                ],
+                "type": "ALL"
+            },
+            "varscan.resultVcfFileIndex": {
+                "contents": [
+                    {
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_varscan_PCSI_chr22_@JENKINSID@"
                     }
                 ],
                 "type": "ALL"

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -144,7 +144,14 @@
             "varscan.smoothData.modules": null,
             "varscan.smoothData.recenter_down": null,
             "varscan.smoothData.recenter_up": null,
-            "varscan.smoothData.varScan": null
+            "varscan.smoothData.varScan": null,
+            "varscan.vcfCombine.vcfSnvs": null,
+            "varscan.vcfCombine.vcfIndels": null,
+            "varscan.vcfCombine.modules": null,
+            "varscan.vcfCombine.outputFileNamePrefix": null,
+            "varscan.vcfCombine.jobMemory": null
+            "varscan.vcfCombine.threads": null,
+            "varscan.vcfCombine.timeout": null			
         },
         "description": "Varscan workflow test",
         "engineArguments": {
@@ -364,7 +371,14 @@
             "varscan.smoothData.modules": null,
             "varscan.smoothData.recenter_down": null,
             "varscan.smoothData.recenter_up": null,
-            "varscan.smoothData.varScan": null
+            "varscan.smoothData.varScan": null,
+            "varscan.vcfCombine.vcfSnvs": null,
+            "varscan.vcfCombine.vcfIndels": null,
+            "varscan.vcfCombine.modules": null,
+            "varscan.vcfCombine.outputFileNamePrefix": null,
+            "varscan.vcfCombine.jobMemory": null
+            "varscan.vcfCombine.threads": null,
+            "varscan.vcfCombine.timeout": null			
         },
         "description": "Varscan workflow test",
         "engineArguments": {
@@ -591,7 +605,14 @@
             "varscan.smoothData.modules": null,
             "varscan.smoothData.recenter_down": null,
             "varscan.smoothData.recenter_up": null,
-            "varscan.smoothData.varScan": null
+            "varscan.smoothData.varScan": null,
+            "varscan.vcfCombine.vcfSnvs": null,
+            "varscan.vcfCombine.vcfIndels": null,
+            "varscan.vcfCombine.modules": null,
+            "varscan.vcfCombine.outputFileNamePrefix": null,
+            "varscan.vcfCombine.jobMemory": null
+            "varscan.vcfCombine.threads": null,
+            "varscan.vcfCombine.timeout": null			
         },
         "description": "Varscan workflow test",
         "engineArguments": {


### PR DESCRIPTION
Currently the workflow produces unzipped vcf files, separately for snvs and indels.
The change her is adding an additional task to merge the calls into a single file, and then bgzip/indexing the ouptut file.  This adds additional output to the workflow.  This is needed as input to the variantMerging workflow, as part of the neoAntigen pipeline.

The current varscan workflow had been built to support sequenza; as such it generates both copy number and mutation calls.   These changes give it a more general use as a variant caller.  

Monica, i also updated the changelog to the current specifications.  Please take a look to verify the change meets the requirements that you are working with on your ticket, and you can then remove it from your list of workfows