### PR TITLE
adjusted changelog to identify a missed tag, 2.5.1 from 2024.  Lastes…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-## [2.5.1] - 2025-03-10
+## [2.5.2] - 2025-03-10
 ### Added
 - Added vcfCombine task to create a final bgzipped vcf with both indels and cnv
+
+## [2.5.1] - 2024-06-27
+### Added
+- Added vidarr file labels
 
 ## [2.5.0] - 2024-06-25
 ### Added


### PR DESCRIPTION
adjusted changelog to identify a missed tag, 2.5.1 from 2024.  


Lastest tags is now 2.5.2 for neoantigen support work