### PR TITLE
updated changelog to indicate missed tag 2.5.1,  latest tag is now 2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.5.1] - 2025-03-10
-### Added
+## [2.5.2] - 2025-03-10
+## Added
 - Added vcfCombine task to create a final bgzipped vcf with both indels and cnv
+
+## [2.5.1] - 2024-06-27
+## Added
+- Added vidarr file labels
 
 ## [2.5.0] - 2024-06-25
 ### Added


### PR DESCRIPTION
I had tagged all my changes with 2.5.1, but this tag already existed and was not recorded in the changelog.

I've now updated the changelog to indicate the date of the 2.5.1 tag, and recorded my changes under 2.5.2
once the merge is done I will tag the latest as 2.5.2
